### PR TITLE
Make Info.plist for Terraform docset valid XML

### DIFF
--- a/website/Rakefile
+++ b/website/Rakefile
@@ -60,9 +60,9 @@ task :setup do
   # Info.plist
   File.open("Terraform.docset/Contents/Info.plist", "w") do |f|
     f.write <<-XML
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
     <dict>
     <key>CFBundleIdentifier</key>
     <string>terraform</string>
@@ -79,7 +79,7 @@ task :setup do
     <key>DashDocSetFallbackURL</key>
     <string>https://www.terraform.io/</string>
     </dict>
-    </plist>
+</plist>
     XML
   end
 end


### PR DESCRIPTION
A quick fix to remove the white space in front of a few lines of the generated `Info.plist`. This was causing [Zeal](https://zealdocs.org) to not show results for the terraform docset when typing `terraform:` in the search box. Not sure if this is affecting Dash or other apps which use Dash docsets.

I guess Zeal is particular about valid XML?