### PR TITLE
documentation type definition for resource/data

### DIFF
--- a/website/Rakefile
+++ b/website/Rakefile
@@ -196,7 +196,17 @@ task :create_index do
     Dir.glob("docs/providers/**/*")
       .find_all{ |f| File.stat(f).file? }.each do |path|
 
-      index.insert "Provider", path
+      maybe_type_code = path.split("/").reverse.drop(1).first
+
+      if maybe_type_code == "r"
+        type = "Resource"
+      elsif maybe_type_code == "d"
+        type = "Directive"
+      else
+        type = "Provider"
+      end
+
+      index.insert type, path
     end
     # provisioners
     Dir.glob("docs/provisioners/**/*")


### PR DESCRIPTION
When searching for terraform resources at Dash, there is no distinction between resource and data type at sqlite db. Everything is inserted as `Provider` type. Now resources will be of type "Resource", data of type "Directive" and the provider index.html of type "Provider". A proper data type is not present, feel free to suggest another one from https://kapeli.com/docsets#supportedentrytypes